### PR TITLE
Fix build issue where Debug not implemented on `syn::Type`.

### DIFF
--- a/typescript-definitions-derive/Cargo.toml
+++ b/typescript-definitions-derive/Cargo.toml
@@ -35,4 +35,4 @@ insta = "0.6.2"
 export-typescript = []
 test = []
 type-guards = []
-
+syn-extra-traits = ["syn/extra-traits"]

--- a/typescript-definitions-derive/src/attrs.rs
+++ b/typescript-definitions-derive/src/attrs.rs
@@ -12,7 +12,7 @@ use quote::quote;
 use proc_macro2::TokenStream;
 use syn::{Attribute, Ident, Lit, Meta, /* MetaList,*/ MetaNameValue, NestedMeta};
 
-#[derive(Debug)]
+#[cfg_attr(feature = "syn-extra-traits", derive(Debug))]
 pub struct Attrs {
     pub comments: Vec<String>,
     pub guard: bool,
@@ -47,8 +47,7 @@ impl Attrs {
             only_first: false,
             ts_type: None,
             ts_guard: None,
-            ts_as : None
-            // isa: HashMap::new(),
+            ts_as: None, // isa: HashMap::new(),
         }
     }
     pub fn push_doc_comment(&mut self, attrs: &[Attribute]) {


### PR DESCRIPTION
Build fails since `syn::Type` only adds an impl for Debug when
"extra-traits" feature is enabled. This exposes a feature on
typescript-definitions-derive to control whether or not syn's feature is
active, and adds a `cfg_attr` to the derive for `Attrs`.

- <https://github.com/dtolnay/syn/issues/583#issuecomment-466830944>

This was mentioned incidentally in #4 but does not solve the breakage starting in `nightly-2019-11-25` which seems to be related to the pest usage.